### PR TITLE
feat: implement Sanity integration with typed mapping and status checks

### DIFF
--- a/app/catalog/page.tsx
+++ b/app/catalog/page.tsx
@@ -1,8 +1,46 @@
-export default function CatalogPage() {
+import { getPolishes, getSanityConnectionStatus } from "@/lib/sanity/queries";
+
+export default async function CatalogPage() {
+  const [polishes, sanityStatus] = await Promise.all([
+    getPolishes(),
+    getSanityConnectionStatus()
+  ]);
+
   return (
     <section className="page">
       <h1>Catalog</h1>
-      <p>Route stub for the full polish gallery and filters.</p>
+      <p
+        className={`status-pill ${
+          sanityStatus.state === "connected"
+            ? "status-ok"
+            : sanityStatus.state === "error"
+              ? "status-error"
+              : "status-warn"
+        }`}
+      >
+        Sanity status: {sanityStatus.state}
+      </p>
+      <p>{sanityStatus.message}</p>
+      <p>
+        {polishes.length > 0
+          ? `Showing ${polishes.length} active polish entries from Sanity.`
+          : "No active polish entries found. Add data in Sanity or set env vars."}
+      </p>
+      {polishes.length > 0 ? (
+        <ul className="card-grid" aria-label="Polish cards">
+          {polishes.map((polish) => (
+            <li key={polish.id} className="card-item">
+              <article>
+                <h2>{polish.title}</h2>
+                <p>
+                  {polish.brand} · {polish.finish}
+                </p>
+                <p>Slug: {polish.slug}</p>
+              </article>
+            </li>
+          ))}
+        </ul>
+      ) : null}
     </section>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -88,6 +88,55 @@ main.site-shell {
   font-weight: 600;
 }
 
+.card-grid {
+  list-style: none;
+  padding: 0;
+  margin: 1.25rem 0 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.85rem;
+}
+
+.card-item {
+  border: 1px solid #f0dfe6;
+  border-radius: 0.8rem;
+  padding: 0.85rem;
+  background: #fff;
+}
+
+.card-item h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+}
+
+.card-item p {
+  margin: 0.25rem 0;
+}
+
+.status-pill {
+  display: inline-block;
+  margin: 0 0 0.75rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.status-ok {
+  background: #e6fbef;
+  border: 1px solid #9dd7b3;
+}
+
+.status-warn {
+  background: #fff4da;
+  border: 1px solid #e6c57c;
+}
+
+.status-error {
+  background: #ffe7e8;
+  border: 1px solid #e2a3a8;
+}
+
 @media (max-width: 680px) {
   .site-header .site-shell {
     flex-direction: column;

--- a/app/picker/page.tsx
+++ b/app/picker/page.tsx
@@ -1,8 +1,30 @@
-export default function PickerPage() {
+import { getNailArt } from "@/lib/sanity/queries";
+
+export default async function PickerPage() {
+  const nailArt = await getNailArt();
+
   return (
     <section className="page">
       <h1>Picker</h1>
-      <p>Route stub for swipe stacks and randomizer workflow.</p>
+      <p>
+        {nailArt.length > 0
+          ? `Loaded ${nailArt.length} active nail-art ideas from Sanity.`
+          : "No active nail-art entries found. Add data in Sanity or set env vars."}
+      </p>
+      {nailArt.length > 0 ? (
+        <ul className="card-grid" aria-label="Nail art cards">
+          {nailArt.map((idea) => (
+            <li key={idea.id} className="card-item">
+              <article>
+                <h2>{idea.title}</h2>
+                <p>Difficulty: {idea.difficulty}</p>
+                <p>Tags: {idea.tags.length > 0 ? idea.tags.join(", ") : "None"}</p>
+                <p>Slug: {idea.slug}</p>
+              </article>
+            </li>
+          ))}
+        </ul>
+      ) : null}
     </section>
   );
 }

--- a/lib/sanity/client.ts
+++ b/lib/sanity/client.ts
@@ -1,0 +1,21 @@
+import { createClient } from "@sanity/client";
+import { isSanityConfigured, sanityEnv } from "@/lib/sanity/env";
+
+const fallbackClient = createClient({
+  projectId: "missing-project-id",
+  dataset: "missing-dataset",
+  apiVersion: sanityEnv.apiVersion,
+  useCdn: false,
+  perspective: "published"
+});
+
+export const sanityClient = isSanityConfigured
+  ? createClient({
+      projectId: sanityEnv.projectId,
+      dataset: sanityEnv.dataset,
+      apiVersion: sanityEnv.apiVersion,
+      token: sanityEnv.token,
+      useCdn: !sanityEnv.token,
+      perspective: "published"
+    })
+  : fallbackClient;

--- a/lib/sanity/env.ts
+++ b/lib/sanity/env.ts
@@ -1,0 +1,17 @@
+const getVar = (key: string): string | undefined => {
+  const value = process.env[key];
+  if (!value) {
+    return undefined;
+  }
+  return value;
+};
+
+export const sanityEnv = {
+  projectId: getVar("NEXT_PUBLIC_SANITY_PROJECT_ID"),
+  dataset: getVar("NEXT_PUBLIC_SANITY_DATASET"),
+  apiVersion: getVar("SANITY_API_VERSION") ?? "2025-01-01",
+  token: getVar("SANITY_API_READ_TOKEN")
+};
+
+export const isSanityConfigured =
+  Boolean(sanityEnv.projectId) && Boolean(sanityEnv.dataset);

--- a/lib/sanity/mappers.ts
+++ b/lib/sanity/mappers.ts
@@ -1,0 +1,79 @@
+import type { NailArtCard, PolishCard } from "@/lib/types/cards";
+
+export type RawPolish = {
+  _id: string;
+  name?: string | null;
+  colorName?: string | null;
+  brand?: string | null;
+  finish?: string | null;
+  polishType?: string | null;
+  colorHex?: string | null;
+  color?: string | null;
+  imageUrl?: string | null;
+  slug?: string | null;
+};
+
+export type RawNailArt = {
+  _id: string;
+  title?: string | null;
+  nailArt?: string | null;
+  difficulty?: string | null;
+  tags?: string[] | null;
+  techniques?: string[] | null;
+  nailArtType?: string | null;
+  needPeely?: boolean | null;
+  needSponge?: boolean | null;
+  needDotter?: boolean | null;
+  needBrush?: boolean | null;
+  needTape?: boolean | null;
+  coverImageUrl?: string | null;
+  description?: string | null;
+  slug?: string | null;
+};
+
+const normalizeSlug = (slug: string | null | undefined, id: string): string => {
+  if (slug && slug.trim().length > 0) {
+    return slug.trim();
+  }
+  return id;
+};
+
+export const mapPolishCard = (doc: RawPolish): PolishCard => ({
+  id: doc._id,
+  title: doc.name?.trim() || doc.colorName?.trim() || "Untitled polish",
+  brand: doc.brand?.trim() || "Unknown brand",
+  finish: doc.finish?.trim() || doc.polishType?.trim() || "Unspecified",
+  colorHex: doc.colorHex?.trim() || doc.color?.trim() || null,
+  imageUrl: doc.imageUrl?.trim() || null,
+  slug: normalizeSlug(doc.slug, doc._id)
+});
+
+export const mapNailArtCard = (doc: RawNailArt): NailArtCard => {
+  const tags = new Set<string>();
+
+  for (const tag of [...(doc.tags ?? []), ...(doc.techniques ?? [])]) {
+    const normalized = tag?.trim();
+    if (normalized) {
+      tags.add(normalized);
+    }
+  }
+
+  if (doc.nailArtType?.trim()) {
+    tags.add(doc.nailArtType.trim());
+  }
+  if (doc.needPeely) tags.add("needs peely");
+  if (doc.needSponge) tags.add("needs sponge");
+  if (doc.needDotter) tags.add("needs dotter");
+  if (doc.needBrush) tags.add("needs brush");
+  if (doc.needTape) tags.add("needs tape");
+
+  return {
+    id: doc._id,
+    title: doc.title?.trim() || doc.nailArt?.trim() || "Untitled nail art",
+    slug: normalizeSlug(doc.slug, doc._id),
+    difficulty: doc.difficulty?.trim() || "Unknown",
+    tags: [...tags],
+    coverImageUrl: doc.coverImageUrl?.trim() || null,
+    description: doc.description?.trim() || ""
+  };
+};

--- a/lib/sanity/queries.ts
+++ b/lib/sanity/queries.ts
@@ -1,0 +1,150 @@
+import groq from "groq";
+import { sanityClient } from "@/lib/sanity/client";
+import { isSanityConfigured } from "@/lib/sanity/env";
+import { mapNailArtCard, mapPolishCard } from "@/lib/sanity/mappers";
+import type { RawNailArt, RawPolish } from "@/lib/sanity/mappers";
+import type { NailArtCard, PolishCard } from "@/lib/types/cards";
+
+export type SanityConnectionStatus =
+  | {
+      state: "not-configured";
+      message: string;
+    }
+  | {
+      state: "connected";
+      message: string;
+    }
+  | {
+      state: "error";
+      message: string;
+    };
+
+const POLISH_QUERY = groq`*[_type == "polish" && coalesce(active, true) == true] | order(lower(brand) asc, lower(name) asc) {
+  _id,
+  name,
+  colorName,
+  brand,
+  finish,
+  polishType,
+  "slug": slug.current,
+  color,
+  "colorHex": coalesce(colorValue.hex, color.hex, colorHex),
+  "imageUrl": coalesce(swatch.asset->url, image.asset->url)
+}`;
+
+const LEGACY_POLISH_QUERY = groq`*[_type == "nailpolish" && coalesce(active, true) == true] | order(lower(brand) asc, lower(colorName) asc) {
+  _id,
+  colorName,
+  brand,
+  polishType,
+  color,
+  "colorHex": colorValue.hex
+}`;
+
+const NAIL_ART_QUERY = groq`*[_type == "nailArt" && coalesce(active, true) == true] | order(_createdAt desc) {
+  _id,
+  title,
+  nailArt,
+  difficulty,
+  "slug": slug.current,
+  "description": coalesce(description, caption),
+  "tags": coalesce(tags, techniques),
+  techniques,
+  nailArtType,
+  needPeely,
+  needSponge,
+  needDotter,
+  needBrush,
+  needTape,
+  "coverImageUrl": coalesce(coverImage.asset->url, image.asset->url)
+}`;
+
+const LEGACY_NAIL_ART_QUERY = groq`*[_type == "nailart" && coalesce(active, true) == true] | order(_createdAt desc) {
+  _id,
+  nailArt,
+  nailArtType,
+  description,
+  needPeely,
+  needSponge,
+  needDotter,
+  needBrush,
+  needTape,
+  tutorialLink
+}`;
+
+const SANITY_HEALTH_QUERY = groq`count(*[_type in ["polish", "nailpolish", "nailArt", "nailart"]])`;
+
+const warnMissingConfig = (() => {
+  let didWarn = false;
+
+  return () => {
+    if (!didWarn) {
+      console.warn(
+        "Sanity env vars are not configured. Returning empty lists for catalog queries."
+      );
+      didWarn = true;
+    }
+  };
+})();
+
+export const getSanityConnectionStatus =
+  async (): Promise<SanityConnectionStatus> => {
+    if (!isSanityConfigured) {
+      return {
+        state: "not-configured",
+        message:
+          "Sanity is not configured. Add NEXT_PUBLIC_SANITY_PROJECT_ID and NEXT_PUBLIC_SANITY_DATASET."
+      };
+    }
+
+    try {
+      await sanityClient.fetch<number>(SANITY_HEALTH_QUERY);
+      return {
+        state: "connected",
+        message: "Connected to Sanity dataset."
+      };
+    } catch (error) {
+      console.error("Sanity health check failed", error);
+      return {
+        state: "error",
+        message:
+          "Could not reach Sanity. Check project ID, dataset, token, and network/DNS access."
+      };
+    }
+  };
+
+export const getPolishes = async (): Promise<PolishCard[]> => {
+  if (!isSanityConfigured) {
+    warnMissingConfig();
+    return [];
+  }
+
+  try {
+    const [modernDocs, legacyDocs] = await Promise.all([
+      sanityClient.fetch<RawPolish[]>(POLISH_QUERY),
+      sanityClient.fetch<RawPolish[]>(LEGACY_POLISH_QUERY)
+    ]);
+    return [...modernDocs, ...legacyDocs].map((doc) => mapPolishCard(doc));
+  } catch (error) {
+    console.error("Failed to fetch polish docs from Sanity", error);
+    return [];
+  }
+};
+
+export const getNailArt = async (): Promise<NailArtCard[]> => {
+  if (!isSanityConfigured) {
+    warnMissingConfig();
+    return [];
+  }
+
+  try {
+    const [modernDocs, legacyDocs] = await Promise.all([
+      sanityClient.fetch<RawNailArt[]>(NAIL_ART_QUERY),
+      sanityClient.fetch<RawNailArt[]>(LEGACY_NAIL_ART_QUERY)
+    ]);
+    return [...modernDocs, ...legacyDocs].map((doc) => mapNailArtCard(doc));
+  } catch (error) {
+    console.error("Failed to fetch nail-art docs from Sanity", error);
+    return [];
+  }
+};

--- a/lib/types/cards.ts
+++ b/lib/types/cards.ts
@@ -1,0 +1,19 @@
+export type PolishCard = {
+  id: string;
+  title: string;
+  brand: string;
+  finish: string;
+  colorHex: string | null;
+  imageUrl: string | null;
+  slug: string;
+};
+
+export type NailArtCard = {
+  id: string;
+  title: string;
+  slug: string;
+  difficulty: string;
+  tags: string[];
+  coverImageUrl: string | null;
+  description: string;
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
This PR implements issue #3 by wiring Sanity into the Next.js app with typed mapping, query helpers, and resilient error handling.

## What changed
- Added Sanity data layer:
  - lib/sanity/env.ts
  - lib/sanity/client.ts
  - lib/sanity/queries.ts
  - lib/sanity/mappers.ts
- Added frontend card types:
  - lib/types/cards.ts
- Wired routes to use Sanity-backed fetchers:
  - app/catalog/page.tsx
  - app/picker/page.tsx
- Added catalog status UI for Sanity connectivity:
  - connected / error / not-configured
- Added styling for status pills and card display:
  - app/globals.css

## Schema compatibility
Queries/mappers support both:
- legacy types: nailpolish, nailart
- newer types: polish, nailArt

## Behavior
- Active filtering applied with coalesce(active, true) == true
- Optional fields are normalized with safe defaults
- Network/query failures no longer crash prerender; pages render with empty arrays + status messaging

## Validation
- npm run lint passes
- npm run build passes
